### PR TITLE
ACCUMULO-3771 Improvements to autoformatting

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ConditionalWriterImpl.java
@@ -657,10 +657,11 @@ class ConditionalWriterImpl implements ConditionalWriter {
     }
   }
 
-  /*
+  /**
    * The purpose of this code is to ensure that a conditional mutation will not execute when its status is unknown. This allows a user to read the row when the
    * status is unknown and not have to worry about the tserver applying the mutation after the scan.
-   * 
+   *
+   * <p>
    * If a conditional mutation is taking a long time to process, then this method will wait for it to finish... unless this exceeds timeout.
    */
   private void invalidateSession(SessionID sessionId, HostAndPort location) throws AccumuloException, AccumuloSecurityException, TableNotFoundException {

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftTransportPool.java
@@ -190,12 +190,10 @@ public class ThriftTransportPool {
     }
 
     final void checkForStuckIO(long threshold) {
-      /*
-       * checking for stuck io needs to be light weight.
-       * 
-       * Tried to call System.currentTimeMillis() and Thread.currentThread() before every io operation.... this dramatically slowed things down. So switched to
-       * incrementing a counter before and after each io operation.
-       */
+      // checking for stuck io needs to be light weight.
+
+      // Tried to call System.currentTimeMillis() and Thread.currentThread() before every io operation.... this dramatically slowed things down. So switched to
+      // incrementing a counter before and after each io operation.
 
       if ((ioCount & 1) == 1) {
         // when ioCount is odd, it means I/O is currently happening

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloOutputFormat.java
@@ -83,7 +83,7 @@ public class AccumuloOutputFormat implements OutputFormat<Text,Mutation> {
 
   /**
    * Sets the connector information needed to communicate with Accumulo in this job.
-   * 
+   *
    * <p>
    * <b>WARNING:</b> Some tokens, when serialized, divulge sensitive information in the configuration as a means to pass the token to MapReduce tasks. This
    * information is BASE64 encoded to provide a charset safe conversion to a string, but this conversion is not intended to be secure. {@link PasswordToken} is

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/InputFormatBase.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/InputFormatBase.java
@@ -376,7 +376,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
 
     /**
      * Initialize a scanner over the given input split using this task attempt configuration.
-     * 
+     *
      * @deprecated since 1.7.0; Use {@link #contextIterators} instead.
      */
     @Deprecated

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationDocGen.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationDocGen.java
@@ -356,12 +356,14 @@ class ConfigurationDocGen {
     new Asciidoc().generate();
   }
 
-  /*
+  /**
    * Generates documentation for conf/accumulo-site.xml file usage. Arguments are: "--generate-doc", file to write to.
-   * 
-   * @param args command-line arguments
-   * 
-   * @throws IllegalArgumentException if args is invalid
+   *
+   * @param args
+   *          command-line arguments
+   *
+   * @throws IllegalArgumentException
+   *           if args is invalid
    */
   public static void main(String[] args) throws FileNotFoundException, UnsupportedEncodingException {
     if (args.length == 2 && args[0].equals("--generate-html")) {

--- a/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
@@ -98,9 +98,9 @@ public class Mutation implements Writable {
     }
   }
 
-  /*
+  /**
    * This is so hashCode & equals can be called without changing this object.
-   * 
+   *
    * It will return a copy of the current data buffer if serialized has not been called previously. Otherwise, this.data will be returned since the buffer is
    * null and will not change.
    */

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/HeapSize.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/HeapSize.java
@@ -30,7 +30,6 @@ package org.apache.accumulo.core.file.blockfile.cache;
  *
  * <pre>
  * public class SampleObject implements HeapSize {
- * 
  *   int[] numbers;
  *   int x;
  * }

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/LruBlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/LruBlockCache.java
@@ -36,29 +36,29 @@ import org.apache.commons.logging.LogFactory;
 /**
  * A block cache implementation that is memory-aware using {@link HeapSize}, memory-bound using an LRU eviction algorithm, and concurrent: backed by a
  * {@link ConcurrentHashMap} and with a non-blocking eviction thread giving constant-time {@link #cacheBlock} and {@link #getBlock} operations.
- * <p>
  *
+ * <p>
  * Contains three levels of block priority to allow for scan-resistance and in-memory families. A block is added with an inMemory flag if necessary, otherwise a
  * block becomes a single access priority. Once a blocked is accessed again, it changes to multiple access. This is used to prevent scans from thrashing the
  * cache, adding a least-frequently-used element to the eviction algorithm.
- * <p>
  *
+ * <p>
  * Each priority is given its own chunk of the total cache to ensure fairness during eviction. Each priority will retain close to its maximum size, however, if
  * any priority is not using its entire chunk the others are able to grow beyond their chunk size.
- * <p>
  *
+ * <p>
  * Instantiated at a minimum with the total size and average block size. All sizes are in bytes. The block size is not especially important as this cache is
  * fully dynamic in its sizing of blocks. It is only used for pre-allocating data structures and in initial heap estimation of the map.
- * <p>
  *
+ * <p>
  * The detailed constructor defines the sizes for the three priorities (they should total to the maximum size defined). It also sets the levels that trigger and
  * control the eviction thread.
- * <p>
  *
+ * <p>
  * The acceptable size is the cache size level which triggers the eviction process to start. It evicts enough blocks to get the size below the minimum size
  * specified.
- * <p>
  *
+ * <p>
  * Eviction happens in a separate thread and involves a single full-scan of the map. It determines how many bytes must be freed to reach the minimum size, and
  * then while scanning determines the fewest least-recently-used blocks necessary from each of the three priorities (would be 3 times bytes to free). It then
  * uses the priority chunk sizes to evict fairly according to the relative sizes and usage.
@@ -511,9 +511,10 @@ public class LruBlockCache implements BlockCache, HeapSize {
     return this.stats.getEvictedCount();
   }
 
-  /*
-   * Eviction thread. Sits in waiting state until an eviction is triggered when the cache size grows above the acceptable level.<p>
-   * 
+  /**
+   * Eviction thread. Sits in waiting state until an eviction is triggered when the cache size grows above the acceptable level.
+   *
+   * <p>
    * Thread is triggered into action by {@link LruBlockCache#runEviction()}
    */
   private static class EvictionThread extends Thread {

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/impl/AbstractLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/impl/AbstractLexicoderTest.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang.ArrayUtils;
 /**
  * Assists in Testing classes that extend {@link org.apache.accumulo.core.client.lexicoder.AbstractEncoder}. It references methods not formally defined in the
  * {@link org.apache.accumulo.core.client.lexicoder.Lexicoder} interface.
- * 
+ *
  * @since 1.7.0
  */
 public abstract class AbstractLexicoderTest extends LexicoderTest {

--- a/core/src/test/java/org/apache/accumulo/core/client/mock/MockNamespacesTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/mock/MockNamespacesTest.java
@@ -210,11 +210,8 @@ public class MockNamespacesTest {
     assertTrue(!c.tableOperations().exists(tableName));
 
     // TODO implement clone in mock
-    /*
-     * c.tableOperations().clone(tableName1, tableName2, false, null, null);
-     * 
-     * assertTrue(c.tableOperations().exists(tableName1)); assertTrue(c.tableOperations().exists(tableName2));
-     */
+    // c.tableOperations().clone(tableName1, tableName2, false, null, null);
+    // assertTrue(c.tableOperations().exists(tableName1)); assertTrue(c.tableOperations().exists(tableName2));
     return;
   }
 

--- a/fate/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/fate/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -256,14 +256,11 @@ public class ZooCache {
         if (cache.containsKey(zPath))
           return;
 
-        /*
-         * The following call to exists() is important, since we are caching that a node does not exist. Once the node comes into existence, it will be added to
-         * the cache. But this notification of a node coming into existence will only be given if exists() was previously called.
-         * 
-         * If the call to exists() is bypassed and only getData() is called with a special case that looks for Code.NONODE in the KeeperException, then
-         * non-existence can not be cached.
-         */
-
+        // The following call to exists() is important, since we are caching that a node does not exist. Once the node comes into existence, it will be added to
+        // the cache. But this notification of a node coming into existence will only be given if exists() was previously called.
+        //
+        // If the call to exists() is bypassed and only getData() is called with a special case that looks for Code.NONODE in the KeeperException, then
+        // non-existence can not be cached.
         Stat stat = zooKeeper.exists(zPath, watcher);
 
         byte[] data = null;

--- a/pom.xml
+++ b/pom.xml
@@ -735,6 +735,19 @@
                 </pluginExecution>
                 <pluginExecution>
                   <pluginExecutionFilter>
+                    <groupId>com.googlecode.maven-java-formatter-plugin</groupId>
+                    <artifactId>maven-java-formatter-plugin</artifactId>
+                    <versionRange>[0.4,)</versionRange>
+                    <goals>
+                      <goal>format</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore />
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <versionRange>[2.13,)</versionRange>
@@ -910,17 +923,21 @@
           <artifactId>maven-java-formatter-plugin</artifactId>
           <version>0.4</version>
           <configuration>
+            <compilerCompliance>${maven.compiler.source}</compilerCompliance>
+            <compilerSource>${maven.compiler.source}</compilerSource>
+            <compilerTargetPlatform>${maven.compiler.target}</compilerTargetPlatform>
             <excludes>
               <exclude>**/thrift/*.java</exclude>
               <exclude>**/proto/*.java</exclude>
             </excludes>
+            <lineEnding>LF</lineEnding>
+            <overrideConfigCompilerVersion>true</overrideConfigCompilerVersion>
           </configuration>
           <dependencies>
             <dependency>
               <groupId>org.eclipse.tycho</groupId>
               <artifactId>org.eclipse.jdt.core</artifactId>
               <version>3.10.0.v20140604-1726</version>
-              <scope>compile</scope>
             </dependency>
           </dependencies>
           <executions>
@@ -976,7 +993,7 @@
               <module name="TreeWalker">
                 <module name="OneTopLevelClass" />
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="[^*]\s+$" />
+                  <property name="format" value="\s+$" />
                   <property name="message" value="Line has trailing whitespace." />
                 </module>
                 <module name="RegexpSinglelineJava">

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
@@ -62,9 +62,9 @@ public class ProblemReports implements Iterable<ProblemReport> {
 
   private final LRUMap problemReports = new LRUMap(1000);
 
-  /*
+  /**
    * use a thread pool so that reporting a problem never blocks
-   * 
+   *
    * make the thread pool use a bounded queue to avoid the case where problem reports are not being processed because the whole system is in a really bad state
    * (like HDFS is down) and everything is reporting lots of problems, but problem reports can not be processed
    */

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TabletIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TabletIterator.java
@@ -48,8 +48,6 @@ import com.google.common.collect.Iterators;
  *
  * If a tablet that was returned by this iterator is subsequently deleted from the metadata table, then this iterator will throw a TabletDeletedException. This
  * could occur when a table is merged.
- *
- *
  */
 public class TabletIterator implements Iterator<Map<Key,Value>> {
 
@@ -77,18 +75,11 @@ public class TabletIterator implements Iterator<Map<Key,Value>> {
     }
   }
 
-  /*
-   * public TabletIterator(String table, boolean returnPrevEndRow){
-   * 
-   * }
-   */
-
   /**
    *
    * @param s
    *          A scanner over the entire metadata table configure to fetch needed columns.
    */
-
   public TabletIterator(Scanner s, Range range, boolean returnPrevEndRow, boolean returnDir) {
     this.scanner = s;
     this.range = range;

--- a/server/gc/src/main/java/org/apache/accumulo/gc/replication/CloseWriteAheadLogReferences.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/replication/CloseWriteAheadLogReferences.java
@@ -115,16 +115,14 @@ public class CloseWriteAheadLogReferences implements Runnable {
     log.debug("Referenced WALs: " + referencedWals);
     sw.reset();
 
-    /*
-     * ACCUMULO-3320 WALs cannot be closed while a TabletServer may still use it later.
-     * 
-     * In addition to the WALs that are actively referenced in the metadata table, tservers can also hold on to a WAL that is not presently referenced by any
-     * tablet. For example, a tablet could MinC which would end in all logs for that tablet being removed. However, if more data was ingested into the table,
-     * the same WAL could be re-used again by that tserver.
-     * 
-     * If this code happened to run after the compaction but before the log is again referenced by a tabletserver, we might delete the WAL reference, only to
-     * have it recreated again which causes havoc with the replication status for a table.
-     */
+    // ACCUMULO-3320 WALs cannot be closed while a TabletServer may still use it later.
+    //
+    // In addition to the WALs that are actively referenced in the metadata table, tservers can also hold on to a WAL that is not presently referenced by any
+    // tablet. For example, a tablet could MinC which would end in all logs for that tablet being removed. However, if more data was ingested into the table,
+    // the same WAL could be re-used again by that tserver.
+    //
+    // If this code happened to run after the compaction but before the log is again referenced by a tabletserver, we might delete the WAL reference, only to
+    // have it recreated again which causes havoc with the replication status for a table.
     final TInfo tinfo = Tracer.traceInfo();
     Set<String> activeWals;
     Span findActiveWalsSpan = Trace.start("findActiveWals");

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CleanUp.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CleanUp.java
@@ -69,11 +69,8 @@ class CleanUp extends MasterRepo {
   private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
     in.defaultReadObject();
 
-    /*
-     * handle the case where we start executing on a new machine where the current time is in the past relative to the previous machine
-     * 
-     * if the new machine has time in the future, that will work ok w/ hasCycled
-     */
+    // handle the case where we start executing on a new machine where the current time is in the past relative to the previous machine
+    // if the new machine has time in the future, that will work ok w/ hasCycled
     if (System.currentTimeMillis() < creationTime) {
       creationTime = System.currentTimeMillis();
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2106,19 +2106,13 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         locationToOpen = VolumeUtil.switchRootTabletVolume(extent, locationToOpen);
 
         tablet = new Tablet(TabletServer.this, extent, locationToOpen, trm, tabletsKeyValues);
-        /*
-         * @formatter:off If a minor compaction starts after a tablet opens, this indicates a log recovery occurred. This recovered data must be minor
-         * compacted.
-         * 
-         * There are three reasons to wait for this minor compaction to finish before placing the tablet in online tablets.
-         * 
-         * 1) The log recovery code does not handle data written to the tablet on multiple tablet servers. 2) The log recovery code does not block if memory is
-         * full. Therefore recovering lots of tablets that use a lot of memory could run out of memory. 3) The minor compaction finish event did not make it to
-         * the logs (the file will be in metadata, preventing replay of compacted data)... but do not want a majc to wipe the file out from metadata and then
-         * have another process failure... this could cause duplicate data to replay.
-         * 
-         * @formatter:on
-         */
+        // If a minor compaction starts after a tablet opens, this indicates a log recovery occurred. This recovered data must be minor compacted.
+        // There are three reasons to wait for this minor compaction to finish before placing the tablet in online tablets.
+        //
+        // 1) The log recovery code does not handle data written to the tablet on multiple tablet servers.
+        // 2) The log recovery code does not block if memory is full. Therefore recovering lots of tablets that use a lot of memory could run out of memory.
+        // 3) The minor compaction finish event did not make it to the logs (the file will be in metadata, preventing replay of compacted data)... but do not
+        // want a majc to wipe the file out from metadata and then have another process failure... this could cause duplicate data to replay.
         if (tablet.getNumEntriesInMemory() > 0 && !tablet.minorCompactNow(MinorCompactionReason.RECOVERY)) {
           throw new RuntimeException("Minor compaction after recovery fails for " + extent);
         }

--- a/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
@@ -102,8 +102,8 @@ public class AccumuloClassLoader {
   }
 
   /**
-   * Parses and XML Document for a property node for a &lt;name&gt; with the value propertyName if it finds one the function return that property's value for
-   * its &lt;value&gt; node. If not found the function will return null
+   * Parses an XML Document for a property node for a &lt;name&gt; with the value propertyName if it finds one the function return that property's value for its
+   * &lt;value&gt; node. If not found the function will return null.
    *
    * @param d
    *          XMLDocument to search through

--- a/test/src/main/java/org/apache/accumulo/test/continuous/ContinuousBatchWalker.java
+++ b/test/src/main/java/org/apache/accumulo/test/continuous/ContinuousBatchWalker.java
@@ -81,16 +81,6 @@ public class ContinuousBatchWalker {
 
   }
 
-  /*
-   * private static void runSequentialScan(Scanner scanner, List<Range> ranges) { Set<Text> srowsSeen = new HashSet<Text>(); long st1 =
-   * System.currentTimeMillis(); int scount = 0; for (Range range : ranges) { scanner.setRange(range);
-   * 
-   * for (Entry<Key,Value> entry : scanner) { srowsSeen.add(entry.getKey().getRow()); scount++; } }
-   * 
-   * 
-   * long st2 = System.currentTimeMillis(); System.out.println("SRQ "+(st2 - st1)+" "+srowsSeen.size() +" "+scount); }
-   */
-
   private static void runBatchScan(int batchSize, BatchScanner bs, Set<Text> batch, List<Range> ranges) {
     bs.setRanges(ranges);
 

--- a/test/src/test/java/org/apache/accumulo/test/functional/ConcurrencyIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/ConcurrencyIT.java
@@ -78,12 +78,17 @@ public class ConcurrencyIT extends AccumuloClusterIT {
     return 2 * 60;
   }
 
-  /*
-   * Below is a diagram of the operations in this test over time.
-   * 
-   * Scan 0 |------------------------------| Scan 1 |----------| Minc 1 |-----| Scan 2 |----------| Scan 3 |---------------| Minc 2 |-----| Majc 1 |-----|
-   */
-
+  // @formatter:off
+  // Below is a diagram of the operations in this test over time.
+  //
+  // Scan 0 |------------------------------|
+  // Scan 1 |----------|
+  // Minc 1  |-----|
+  // Scan 2   |----------|
+  // Scan 3               |---------------|
+  // Minc 2                |-----|
+  // Majc 1                       |-----|
+  // @formatter:on
   @Test
   public void run() throws Exception {
     Connector c = getConnector();


### PR DESCRIPTION
- Ensure line endings are consistent
- Eliminate whitespace in non-javadoc block comments
- Insert @formatter:off/on tags to prevent some reformatting
- Make eclipse ignore the plugin
